### PR TITLE
Prepare rel 0.3.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [0.3.0] - 2024-03-10
+
+- When producing the HTML static site, create a file called `doc_versions.js`, containing the list of versions (name and url) specified in the `version` entry of the `html_theme_options`.
+- Change the CSS layout so that the grid centers itself, regardless of whether the toc at the right side is visible or not.
+
 ## [0.2.3] - 2024-02-20
 
 - Use a fluid layout (Bootstrap's `container-fluid`) to allow expanding the TOC

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -4,7 +4,7 @@ import { MenuHandler } from "./menu.js";
 import { updateRepoMetrics } from "./repometrics.js";
 import { TocObserver } from "./pagetoc.js";
 import { resizeAsides, updateScrollPaddingTop } from "./tocresize.js";
-import { updateVersion } from "./versions.js";
+import { feedVersionsMenu, updateVersion } from "./versions.js";
 
 
 function agentHas(keyword) {
@@ -55,6 +55,9 @@ window.addEventListener('DOMContentLoaded', (_) => {
   // them.
   const luz_handler = new LuzHandler();
   luz_handler.registerClickEvents();
+
+  // Feed the versions dropdown element.
+  feedVersionsMenu();
 
   // The updateVersion function controls the display of the version
   // in the header, adding the CSS class "current" to display the

--- a/js/src/tocresize.js
+++ b/js/src/tocresize.js
@@ -30,21 +30,7 @@ export function resizeAsides() {
     nftt_toc?.setAttribute("style", height);
   }
 
-  // Compute new 'grid-template-columns' for nftt-layout.
-  const max = (window.innerWidth - nftt_content.offsetWidth);
-  const newmax = nftt_toc
-    ? Math.floor(max / 2)
-    : (
-      nftt_sidebar_content
-        ? Math.floor((max + nftt_sidebar_content.offsetWidth) / 2)
-        : undefined
-    );
-  if (newmax) {
-    const newgtcols = `minmax(300px, ${newmax}px) 5fr`;
-    nftt_layout?.setAttribute("style", `grid-template-columns: ${newgtcols}`);
-  }
-
-  return [height, newmax];
+  return height;
 }
 
 

--- a/js/src/versions.js
+++ b/js/src/versions.js
@@ -32,3 +32,39 @@ export function updateVersion() {
     }
   }
 }
+
+export function feedVersionsMenu() {
+  const vermenu = document.getElementById("versions-dropdown-menu");
+  if (!vermenu) {
+    console.log("Did not find the versions dropdown menu.");
+    return;
+  }
+  // Use the variable 'doc_versions', loaded as a script in layout.html.
+  // The file doc_versions.js is produced by versions.py when building
+  // the site (make html).
+  console.log("Found the versions dropdown menu!");
+  console.log("doc_versions are:");
+  console.dir(doc_versions);
+
+  for (const item of doc_versions) {
+    const li = document.createElement("li");
+    const anchor = document.createElement("a");
+    anchor.classList.add(
+      "dropdown-item", "d-flex", "align-items-center",
+      "justify-content-between"
+    );
+    anchor.setAttribute("aria-pressed", "false");
+    anchor.setAttribute("href", item.url);
+    anchor.dataset.snfttVersionUrl = item.url;
+    anchor.dataset.snfttVersion = item.name;
+    const span = document.createElement("span");
+    span.classList.add("small", "ms-2");
+    span.textContent = item.name;
+    const i = document.createElement("i");
+    i.classList.add("bi", "bi-check", "ms-auto");
+    anchor.append(span);
+    anchor.append(i);
+    li.append(anchor);
+    vermenu.append(li);
+  }
+}

--- a/js/tests/unit/tocresize.spec.js
+++ b/js/tests/unit/tocresize.spec.js
@@ -70,8 +70,8 @@ describe('resize', () => {
       }
     );
 
-    const results = resizeAsides();
-    expect(results[0]).toEqual("height: calc(100vh - 7rem)");
+    const result = resizeAsides();
+    expect(result).toEqual("height: calc(100vh - 7rem)");
   });
 
   it('checks resizeAsides when nftt_content shorter than body', () => {
@@ -90,7 +90,7 @@ describe('resize', () => {
       }
     );
 
-    const results = resizeAsides();
-    expect(results[0]).toEqual(expected_height);
+    const result = resizeAsides();
+    expect(result).toEqual(expected_height);
   });
 });

--- a/scss/_layout.scss
+++ b/scss/_layout.scss
@@ -43,13 +43,13 @@ body {
   }
 
   @include media-breakpoint-down(lg) {
-    max-width: 892px;
-    margin-inline: auto;
     grid-template-areas:
       "toc"
       "content";
     grid-template-rows: 1fr auto;
     grid-template-columns: none;
+    max-width: 892px;
+    margin-inline: auto;
   }
 }
 

--- a/scss/_layout.scss
+++ b/scss/_layout.scss
@@ -23,16 +23,51 @@ body {
   padding-top: 63px;
 }
 
-.nftt-layout {
+.nftt-page {
   flex: 1 0 auto;
   margin-top: 2.5rem;
   margin-bottom: 1.5rem;
 
   @include media-breakpoint-up(xl) {
     display: grid;
-    grid-template-areas: "sidebar main";
-    grid-template-columns: minmax(300px, 1.5fr) 5fr;
+    grid-template-areas: "sidebar content toc";
+    grid-template-columns: minmax(300px, 1.5fr) minmax(570px, 760px) minmax(190px, 1.3fr);
     gap: 25px;
+  }
+
+  @include media-breakpoint-down(xl) {
+    display: grid;
+    grid-template-areas: "content toc";
+    grid-template-columns: minmax(570px, 5fr) minmax(190px, 1fr);
+    gap: 25px;
+  }
+
+  @include media-breakpoint-down(lg) {
+    max-width: 892px;
+    margin-inline: auto;
+    grid-template-areas:
+      "toc"
+      "content";
+    grid-template-rows: 1fr auto;
+    grid-template-columns: none;
+  }
+}
+
+.nftt-page-wo-toc {
+  flex: 1 0 auto;
+  margin-top: 2.5rem;
+  margin-bottom: 1.5rem;
+
+  @include media-breakpoint-up(xl) {
+    display: grid;
+    grid-template-areas: "sidebar content toc";
+    grid-template-columns: minmax(300px, 1.5fr) minmax(570px, 760px) minmax(190px, 1.3fr);
+    gap: 25px;
+  }
+
+  @include media-breakpoint-down(xl) {
+    max-width: 92%;
+    margin-inline: auto;
   }
 }
 
@@ -59,39 +94,6 @@ body {
   }
 }
 
-.nftt-main-wo-toc {
-  display: grid;
-  grid-area: main;
-  grid-template-areas: "content";
-  grid-template-columns: minmax(570px, 860px);
-  padding-right: 48px;
-
-  @include media-breakpoint-down(xl) {
-    grid-template-columns: none;
-    padding-right: 0;
-  }
-}
-
-.nftt-main {
-  display: grid;
-  grid-area: main;
-  grid-template-areas:
-    "toc"
-    "content";
-  grid-template-rows: 1fr auto;
-  gap: inherit;
-
-  @include media-breakpoint-down(xl) {
-    max-width: 1100px;
-    margin-inline: auto;
-  }
-
-  @include media-breakpoint-up(lg) {
-    grid-template-areas: "content toc";
-    grid-template-columns: minmax(570px, 760px) minmax(190px, 1.3fr);
-  }
-}
-
 .nftt-toc {
   grid-area: toc;
 
@@ -100,6 +102,12 @@ body {
     font-family: var(--#{$prefix}font-monospace);
     font-size: .7rem;
   }
+
+  @include media-breakpoint-down(lg) {
+    padding-right: 2rem;
+    padding-left: 2rem;
+  }
+
 }
 
 

--- a/scss/components/_toc.scss
+++ b/scss/components/_toc.scss
@@ -203,7 +203,7 @@
   display: flex;
   align-items: center;
 
-  @include media-breakpoint-down(sm) {
+  @include media-breakpoint-down(md) {
     justify-content: space-between;
     width: 100%;
   }

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(BASE_DIR / "requirements.txt", "r") as req_file:
 
 setup(
     name="sphinx-nefertiti",
-    version="0.2.3",
+    version="0.3.0",
     packages=find_packages(),
     include_package_data=True,
     license="MIT",

--- a/site/apidoc.html
+++ b/site/apidoc.html
@@ -1,0 +1,847 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="/css/bootstrap-icons.css">
+  <link rel="stylesheet" href="/css/sphinx-nefertiti.css">
+  <link rel="stylesheet" type="text/css" href="/css/pygments.css">
+  <link id="pygments_dark_css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css" href="/css/pygments_dark.css">
+  <link rel="stylesheet" type="text/css" href="/css/pygments_dark.css">
+  <title>Nefertiti Theme documentation &mdash; Nefertiti for Sphinx 0.1.0 documentation</title>
+  <style>
+    :root {
+      --nftt-body-font-family: "Verdana", var(--nftt-font-sans-serif) !important;
+      --nftt-font-monospace: "Monaco", var(--nftt-font-family-monospace) !important;
+      --nftt-font-monospace-size: 0.8rem;
+      --nftt-project-name-font: "Tahoma", var(--nftt-body-font-family);
+      --nftt-documentation-font: "Palatino", var(--nftt-body-font-family);
+      --nftt-documentation-font-size: 1.1rem;
+      --nftt-doc-headers-font: "Georgia", var(--nftt-documentation-font);
+    }
+
+    .nefertiti-bg {
+      margin-right: 1rem;
+      background: white;
+      border: 0;
+      border-radius: 50%;
+      height: 36px;
+      width: 36px;
+    }
+  </style>
+</head>
+
+<body>
+  <header class="navbar navbar-expand-xl navbar-dark nftt-navbar flex-column fixed-top">
+    <div class="skip-links container-xxl visually-hidden-focusable overflow-hidden justify-content-start">
+      <div class="border-bottom mb-2 pb-2 w-100">
+        <a class="d-none d-md-inline-flex p-2 m-1" href="#sidebar-filter">Skip to docs navigation</a>
+        <a class="d-inline-flex p-2 m-1" href="#content">Skip to main content</a>
+      </div>
+    </div>
+    <nav class="container-xxl nftt-gutter flex-wrap flex-xl-nowrap" aria-label="Main navigation">
+      <div class="nftt-navbar-toggler">
+        <button class="navbar-toggler p-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebar" aria-controls="sidebar" aria-label="Toggle documentation navigation">
+          <i class="bi bi-list"></i>
+        </button>
+      </div>
+      <a class="navbar-brand me-0 md-lg-2" href="/" aria-label="Nefertiti for Sphinx">
+        <img src="img/nefertiti.svg" width="36" height="36" class="nefertiti-bg" alt="Nefertiti for Sphinx"><span class="brand-text">Nefertiti for Sphinx</span>
+      </a>
+      <div class="d-flex d-xl-none">
+        <button class="navbar-toggler p-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#nfttSearch" aria-controls="nfttSearch" aria-label="Search">
+          <i class="bi bi-search"></i>
+        </button>
+        <button class="navbar-toggler p-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#nfttNavbar" aria-controls="nfttNavbar" aria-label="Toggle navigation">
+          <i class="bi bi-three-dots"></i>
+        </button>
+      </div>
+
+      <div class="offcanvas-xl offcanvas-end flex-grow-1" tabindex="-1" id="nfttSearch" aria-labelledby="nfttSearchOffcanvasLabel" data-bs-scroll="true">
+        <div class="offcanvas-header px-4 pb-0">
+          <h5 class="offcanvas-title fw-bold" id="nfttSearchOffcanvasLabel">Search the documentation</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close" data-bs-target="#nfttSearch"></button>
+        </div>
+        <div class="offcanvas-body p-4 pt-0 p-xl-0 px-xl-3">
+          <hr class="d-xl-none text-white-50">
+          <ul class="navbar-nav flex-row align-items-center flex-wrap ms-md-auto">
+            <li class="nav-item col-12 col-xl-auto">
+              <div class="input-group">
+                <input type="text" class="form-control" placeholder="Search" aria-label="Search" aria-describedby="button-search">
+                <button class="btn btn-primary" type="button" id="button-search" aria-label="Submit seatch">
+                  <i class="bi bi-search"></i>
+                </button>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="offcanvas-xl offcanvas-end" tabindex="-1" id="nfttNavbar" aria-labelledby="nfttNavbarOffcanvasLabel" data-bs-scroll="true">
+        <div class="offcanvas-header px-4 pb-0">
+          <div class="offcanvas-title navbar-brand" id="nfttNavbarOffcanvasLabel"><span class="brand-text">Nefertiti for Sphinx</span></div>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close" data-bs-target="#nfttNavbar"></button>
+        </div>
+        <div class="offcanvas-body p-4 pt-0 p-xl-0">
+          <hr class="d-xl-none text-white-50">
+          <ul class="navbar-nav flex-row align-items-center flex-wrap ms-lg-auto">
+
+            <li class="nav-item col-12 col-xl-auto">
+              <a class="nav-link py-2 py-xl-0 px-0 px-xl-2" href="https://example.com" target="_blank" rel="noopener" aria-label="Visit repository https://example.com">
+                <div class="d-flex align-items-center">
+                  <div class="me-2">
+                    <i class="bi bi-git size-24"></i>
+                  </div>
+                  <div class="repo d-flex flex-column" data-snftt-repo-url="https://github.com/danirus/django-comments-xtd">
+                    danirus/django-comments-xtd
+                    <div class="d-flex justify-content-center" data-snftt-repo-metrics>
+                      <span class="pe-2 d-flex justify-content-center align-items-center">
+                        <i class="bi bi-tag size-14"></i>
+                        <span class="repo-metric" data-snftt-repo-tag></span>
+                      </span>
+                      <span class="pe-2 d-flex justify-content-center align-items-center">
+                        <i class="bi bi-star size-14"></i>
+                        <span class="repo-metric" data-snftt-repo-stars></span>
+                      </span>
+                      <span class="d-flex justify-content-center align-items-center">
+                        <i class="bi bi-diagram-2 size-14"></i>
+                        <span class="repo-metric" data-snftt-repo-forks></span>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </a>
+            </li>
+
+            <li class="nav-item col-12 col-xl-auto h-100" aria-hidden="true">
+              <div class="vr d-none d-xl-flex h-100 mx-xl-2 text-white"></div>
+              <hr class="d-xl-none text-white-50">
+            </li>
+
+            <!-- versions -->
+            <li class="nav-item dropdown">
+              <a class="nav-link d-flex py-2 px-0 px-xl-2 dropdown-toggle align-items-center" id="snftt-version" href="#" data-bs-toggle="dropdown" data-bs-display="static" aria-label="Select version">
+                <span id="snftt-version-text" class="d-xl-none small">Select version</span>
+                <span class="small ms-2" data-snftt-version-active>v1.0.0</span>
+              </a>
+              <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="snftt-version-text">
+                <li>
+                  <h6 class="dropdown-header">Versions</h6>
+                </li>
+                <li>
+                  <a class="dropdown-item d-flex align-items-center justify-content-between" aria-pressed="false" href="index.html?v=1.0.0" data-snftt-version-url="index.html?v=1.0.0" data-snftt-version="v1.0.0">
+                    <span class="small ms-2">v1.0.0</span>
+                    <i class="bi bi-check ms-auto"></i>
+                  </a>
+                </li>
+                <li>
+                  <a class="dropdown-item d-flex align-items-center justify-content-between" aria-pressed="false" href="index.html?v=0.4.0" data-snftt-version-url="index.html?v=0.4.0" data-snftt-version="v0.4.0">
+                    <span class="small ms-2">v0.4.0</span>
+                    <i class="bi bi-check ms-auto"></i>
+                  </a>
+                </li>
+              </ul>
+            </li>
+
+            <li class="nav-item col-12 col-xl-auto h-100" aria-hidden="true">
+              <div class="vr d-none d-xl-flex h-100 mx-xl-2 text-white"></div>
+              <hr class="d-xl-none text-white-50">
+            </li>
+
+            <li class="nav-item dropdown">
+              <a class="nav-link d-flex py-2 px-0 px-xl-2 dropdown-toggle align-items-center" id="snftt-color" href="#" data-bs-toggle="dropdown" data-bs-display="static" aria-expanded="false" aria-label="Toggle color set">
+                <i class="bi bi-palette"></i>
+                <span id="snftt-color-text" class="d-xl-none small ms-2">Change color set</span>
+              </a>
+              <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="snftt-color-text">
+                <li>
+                  <h6 class="dropdown-header">Change color set</h6>
+                </li>
+                <li>
+                  <a class="dropdown-item d-flex align-items-center" data-snftt-color="blue" href="#" aria-pressed="false">
+                    <span class="blue small">
+                      <i class="bi bi-circle-fill"></i>
+                    </span>
+                    <span class="small ms-3">Blue</span>
+                    <i class="bi bi-check ms-auto"></i>
+                  </a>
+                </li>
+                <li>
+                  <a class="dropdown-item d-flex align-items-center" data-snftt-color="indigo" href="#" aria-pressed="false">
+                    <span class="indigo small">
+                      <i class="bi bi-circle-fill"></i>
+                    </span>
+                    <span class="small ms-3">Indigo</span>
+                    <i class="bi bi-check ms-auto"></i>
+                  </a>
+                </li>
+                <li>
+                  <a class="dropdown-item d-flex align-items-center" data-snftt-color="purple" href="#" aria-pressed="false">
+                    <span class="purple small">
+                      <i class="bi bi-circle-fill"></i>
+                    </span>
+                    <span class="small ms-3">Purple</span>
+                    <i class="bi bi-check ms-auto"></i>
+                  </a>
+                </li>
+                <li>
+                  <a class="dropdown-item d-flex align-items-center" data-snftt-color="pink" href="#" aria-pressed="false">
+                    <span class="pink small">
+                      <i class="bi bi-circle-fill"></i>
+                    </span>
+                    <span class="small ms-3">Pink</span>
+                    <i class="bi bi-check ms-auto"></i>
+                  </a>
+                </li>
+                <li>
+                  <a class="dropdown-item d-flex align-items-center" data-snftt-color="red" href="#" aria-pressed="false">
+                    <span class="red small">
+                      <i class="bi bi-circle-fill"></i>
+                    </span>
+                    <span class="small ms-3">Red</span>
+                    <i class="bi bi-check ms-auto"></i>
+                  </a>
+                </li>
+                <li>
+                  <a class="dropdown-item d-flex align-items-center" data-snftt-color="orange" href="#" aria-pressed="false">
+                    <span class="orange small">
+                      <i class="bi bi-circle-fill"></i>
+                    </span>
+                    <span class="small ms-3">Orange</span>
+                    <i class="bi bi-check ms-auto"></i>
+                  </a>
+                </li>
+                <li>
+                  <a class="dropdown-item d-flex align-items-center" data-snftt-color="yellow" href="#" aria-pressed="false">
+                    <span class="yellow small">
+                      <i class="bi bi-circle-fill"></i>
+                    </span>
+                    <span class="small ms-3">Yellow</span>
+                    <i class="bi bi-check ms-auto"></i>
+                  </a>
+                </li>
+                <li>
+                  <a class="dropdown-item d-flex align-items-center" data-snftt-color="green" href="#" aria-pressed="false">
+                    <span class="green small">
+                      <i class="bi bi-circle-fill"></i>
+                    </span>
+                    <span class="small ms-3">Green</span>
+                    <i class="bi bi-check ms-auto"></i>
+                  </a>
+                </li>
+                <li>
+                  <a class="dropdown-item d-flex align-items-center" data-snftt-color="teal" href="#" aria-pressed="false">
+                    <span class="teal small">
+                      <i class="bi bi-circle-fill"></i>
+                    </span>
+                    <span class="small ms-3">Teal</span>
+                    <i class="bi bi-check ms-auto"></i>
+                  </a>
+                </li>
+                <li>
+                  <a class="dropdown-item current d-flex align-items-center" data-snftt-color="cyan" href="#" aria-pressed="false">
+                    <span class="cyan small">
+                      <i class="bi bi-circle-fill"></i>
+                    </span>
+                    <span class="small ms-3">Cyan</span>
+                    <i class="bi bi-check ms-auto"></i>
+                  </a>
+                </li>
+              </ul>
+            </li>
+
+            <li class="nav-item col-12 col-xl-auto h-100" aria-hidden="true">
+              <div class="vr d-none d-xl-flex h-100 mx-xl-2 text-white"></div>
+              <hr class="d-xl-none text-white-50">
+            </li>
+
+            <li class="nav-item dropdown">
+              <a class="nav-link d-flex py-2 px-0 px-xl-2 dropdown-toggle align-items-center" id="snftt-luz" href="#" data-bs-toggle="dropdown" data-bs-display="static" aria-expanded="false" aria-label="Toggle light/dark">
+                <i class="bi bi-circle-half" data-snftt-luz-icon-active></i>
+                <span id="snftt-luz-text" class="d-xl-none small ms-2">Toggle light/dark</span>
+              </a>
+              <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="snftt-luz-text">
+                <li>
+                  <h6 class="dropdown-header">Light/dark</h6>
+                </li>
+                <li>
+                  <a class="dropdown-item d-flex align-items-center" data-snftt-luz="light" href="#" aria-pressed="false">
+                    <span class="small">
+                      <i class="bi bi-sun" data-snftt-luz-icon="light"></i>
+                    </span>
+                    <span class="small ms-3">Light</span>
+                    <i class="bi bi-check ms-auto"></i>
+                  </a>
+                </li>
+                <li>
+                  <a class="dropdown-item d-flex align-items-center" data-snftt-luz="dark" href="#" aria-pressed="false">
+                    <span class="small">
+                      <i class="bi bi-moon-stars" data-snftt-luz-icon="dark"></i>
+                    </span>
+                    <span class="small ms-3">Dark</span>
+                    <i class="bi bi-check ms-auto"></i>
+                  </a>
+                </li>
+                <li>
+                  <a class="dropdown-item current d-flex align-items-center" data-snftt-luz="default" href="#" aria-pressed="false">
+                    <span class="small">
+                      <i class="bi bi-circle-half" data-snftt-luz-icon="default"></i>
+                    </span>
+                    <span class="small ms-3">Default</span>
+                    <i class="bi bi-check ms-auto"></i>
+                  </a>
+                </li>
+              </ul>
+            </li>
+
+          </ul>
+        </div>
+      </div>
+    </nav>
+  </header>
+
+
+  <div class="container-fluid">
+    <div class="nftt-gutter nftt-page">
+      <aside class="nftt-sidebar">
+        <div class="nftt-sidebar-content">
+          <div class="title d-none d-xl-block">
+            <i class="bi bi-book"></i>&nbsp;&nbsp;<span>Table of contents</span>
+          </div>
+          <div id="sidebar" tabindex="-1" class="offcanvas-xl offcanvas-start" aria-labelledby="nfttSidebarOffcanvasLabel">
+            <!-- danirus sidebartemplate: "globaltoc.html" -->
+            <div class="offcanvas-header border-bottom">
+              <h5 class="offcanvas-title fw-bold" id="nfttSidebarOffcanvasLabel">
+                Table of contents
+              </h5>
+              <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close" data-bs-target="#sidebar"></button>
+            </div>
+
+            <div class="offcanvas-body">
+              <nav class="toc" aria-label="Main menu">
+                <div class="mb-3 p-1 pt-3 pb-4 border-bottom">
+                  <input id="sidebar-filter" type="text" name="filter" class="form-control form-control-sm" placeholder="filter" aria-label="filter">
+                </div>
+                <ul class="current">
+                  <li class="toctree-l1 current"><a class="reference internal" href="index.html">Kitchen Sink</a>
+                    <ul class="current">
+                      <li class="toctree-l2"><a class="reference internal" href="admonitions.html">Admonitions</a></li>
+                      <li class="toctree-l2 current"><a class="current reference internal" href="#">API documentation</a></li>
+                      <li class="toctree-l2"><a class="reference internal" href="blocks.html">Blocks</a></li>
+                      <li class="toctree-l2"><a class="reference internal" href="generic.html">Generic items</a></li>
+                      <li class="toctree-l2"><a class="reference internal" href="images.html">Images &amp; Figures</a></li>
+                      <li class="toctree-l2"><a class="reference internal" href="lists.html">Lists</a></li>
+                      <li class="toctree-l2"><a class="reference internal" href="really-long.html">Really Long Page Title because we should test sidebar wrapping</a></li>
+                      <li class="toctree-l2"><a class="reference internal" href="structure.html">Structural Elements</a></li>
+                      <li class="toctree-l2"><a class="reference internal" href="structure.html#structural-elements-2">Structural Elements 2</a></li>
+                      <li class="toctree-l2"><a class="reference internal" href="tables.html">Tables</a></li>
+                      <li class="toctree-l2"><a class="reference internal" href="typography.html">Typography</a></li>
+                    </ul>
+                  </li>
+                </ul>
+                <p class="caption" role="heading"><span class="caption-text">This is a caption</span></p>
+                <ul>
+                  <li class="toctree-l1"><a class="reference internal" href="../placeholder-one.html">Placeholder Page One</a></li>
+                  <li class="toctree-l1"><a class="reference internal" href="../placeholder-two.html">Placeholder Page Two</a></li>
+                  <li class="toctree-l1"><a class="reference internal" href="../really-long-title.html">This is just a page with a really long title for checking how the theme handles these situations</a></li>
+                  <li class="toctree-l1"><a class="reference internal" href="../long-page.html">Long Page</a></li>
+                  <li class="toctree-l1"><a class="reference external" href="https://www.sphinx-doc.org">External Link</a></li>
+                </ul>
+
+              </nav>
+              <template data-toggle-item-template>
+                <button class="btn btn-sm btn-link toctree-expand" type="button">
+                  <i class="bi bi-caret-right"></i>
+                  <span class="visually-hidden">Toggle menu contents</span>
+                </button>
+              </template>
+            </div>
+          </div>
+        </div>
+      </aside>
+
+      <article id="content" class="nftt-content" role="main">
+        <section id="api-documentation">
+          <h1>API documentation<a class="headerlink" href="#api-documentation" title="Link to this heading">¶</a></h1>
+          <p>Using Sphinx’s <code class="xref any docutils literal notranslate"><span class="pre">sphinx.ext.autodoc</span></code> plugin, it is possible to auto-generate documentation of a Python module.</p>
+          <div class="admonition tip">
+            <p class="admonition-title">Tip</p>
+            <p>Avoid having in-function-signature type annotations with autodoc,
+              by setting the following options:</p>
+            <div class="highlight-python notranslate">
+              <div class="highlight">
+                <pre><span></span><span class="c1"># -- Options for autodoc ----------------------------------------------------</span>
+    <span class="c1"># https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#configuration</span>
+
+    <span class="c1"># Automatically extract typehints when specified and place them in</span>
+    <span class="c1"># descriptions of the relevant function/method.</span>
+    <span class="n">autodoc_typehints</span> <span class="o">=</span> <span class="s2">&quot;description&quot;</span>
+
+    <span class="c1"># Don&#39;t show class signature with the class&#39; name.</span>
+    <span class="n">autodoc_class_signature</span> <span class="o">=</span> <span class="s2">&quot;separated&quot;</span>
+    </pre>
+              </div>
+            </div>
+          </div>
+          <p id="module-urllib.parse">Parse (absolute and relative) URLs.</p>
+          <p>urlparse module is based upon the following RFC specifications.</p>
+          <p>RFC 3986 (STD66): “Uniform Resource Identifiers” by T. Berners-Lee, R. Fielding
+            and L. Masinter, January 2005.</p>
+          <p>RFC 2732 : “Format for Literal IPv6 Addresses in URL’s by R.Hinden, B.Carpenter
+            and L.Masinter, December 1999.</p>
+          <p>RFC 2396: “Uniform Resource Identifiers (URI)”: Generic Syntax by T.
+            Berners-Lee, R. Fielding, and L. Masinter, August 1998.</p>
+          <p>RFC 2368: “The mailto URL scheme”, by P.Hoffman , L Masinter, J. Zawinski, July 1998.</p>
+          <p>RFC 1808: “Relative Uniform Resource Locators”, by R. Fielding, UC Irvine, June
+            1995.</p>
+          <p>RFC 1738: “Uniform Resource Locators (URL)” by T. Berners-Lee, L. Masinter, M.
+            McCahill, December 1994</p>
+          <p>RFC 3986 is considered the current standard and any future changes to
+            urlparse module should conform with it. The urlparse module is
+            currently not entirely compliant with this RFC due to defacto
+            scenarios for parsing, and for backward compatibility purposes, some
+            parsing quirks from older RFCs are retained. The testcases in
+            test_urlparse.py provides a good indicator of parsing behavior.</p>
+          <dl class="py class">
+            <dt class="sig sig-object py" id="urllib.parse.DefragResult">
+              <em class="property"><span class="pre">class</span><span class="w"> </span></em><span class="sig-prename descclassname"><span class="pre">urllib.parse.</span></span><span class="sig-name descname"><span class="pre">DefragResult</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">url</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">fragment</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/urllib/parse.html#DefragResult"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#urllib.parse.DefragResult" title="Link to this definition">¶</a>
+            </dt>
+            <dd></dd>
+          </dl>
+
+          <dl class="py class">
+            <dt class="sig sig-object py" id="urllib.parse.DefragResultBytes">
+              <em class="property"><span class="pre">class</span><span class="w"> </span></em><span class="sig-prename descclassname"><span class="pre">urllib.parse.</span></span><span class="sig-name descname"><span class="pre">DefragResultBytes</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">url</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">fragment</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/urllib/parse.html#DefragResultBytes"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#urllib.parse.DefragResultBytes" title="Link to this definition">¶</a>
+            </dt>
+            <dd></dd>
+          </dl>
+
+          <dl class="py class">
+            <dt class="sig sig-object py" id="urllib.parse.ParseResult">
+              <em class="property"><span class="pre">class</span><span class="w"> </span></em><span class="sig-prename descclassname"><span class="pre">urllib.parse.</span></span><span class="sig-name descname"><span class="pre">ParseResult</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">scheme</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">netloc</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">path</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">params</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">query</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">fragment</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/urllib/parse.html#ParseResult"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#urllib.parse.ParseResult" title="Link to this definition">¶</a>
+            </dt>
+            <dd></dd>
+          </dl>
+
+          <dl class="py class">
+            <dt class="sig sig-object py" id="urllib.parse.ParseResultBytes">
+              <em class="property"><span class="pre">class</span><span class="w"> </span></em><span class="sig-prename descclassname"><span class="pre">urllib.parse.</span></span><span class="sig-name descname"><span class="pre">ParseResultBytes</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">scheme</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">netloc</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">path</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">params</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">query</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">fragment</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/urllib/parse.html#ParseResultBytes"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#urllib.parse.ParseResultBytes" title="Link to this definition">¶</a>
+            </dt>
+            <dd></dd>
+          </dl>
+
+          <dl class="py class">
+            <dt class="sig sig-object py" id="urllib.parse.SplitResult">
+              <em class="property"><span class="pre">class</span><span class="w"> </span></em><span class="sig-prename descclassname"><span class="pre">urllib.parse.</span></span><span class="sig-name descname"><span class="pre">SplitResult</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">scheme</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">netloc</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">path</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">query</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">fragment</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/urllib/parse.html#SplitResult"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#urllib.parse.SplitResult" title="Link to this definition">¶</a>
+            </dt>
+            <dd></dd>
+          </dl>
+
+          <dl class="py class">
+            <dt class="sig sig-object py" id="urllib.parse.SplitResultBytes">
+              <em class="property"><span class="pre">class</span><span class="w"> </span></em><span class="sig-prename descclassname"><span class="pre">urllib.parse.</span></span><span class="sig-name descname"><span class="pre">SplitResultBytes</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">scheme</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">netloc</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">path</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">query</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">fragment</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/urllib/parse.html#SplitResultBytes"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#urllib.parse.SplitResultBytes" title="Link to this definition">¶</a>
+            </dt>
+            <dd></dd>
+          </dl>
+
+          <dl class="py function">
+            <dt class="sig sig-object py" id="urllib.parse.parse_qs">
+              <span class="sig-prename descclassname"><span class="pre">urllib.parse.</span></span><span class="sig-name descname"><span class="pre">parse_qs</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">qs</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">keep_blank_values</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">False</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">strict_parsing</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">False</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">encoding</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">'utf-8'</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">errors</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">'replace'</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">max_num_fields</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">separator</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">'&amp;'</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/urllib/parse.html#parse_qs"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#urllib.parse.parse_qs" title="Link to this definition">¶</a>
+            </dt>
+            <dd>
+              <p>Parse a query given as a string argument.</p>
+              <p>Arguments:</p>
+              <p>qs: percent-encoded query string to be parsed</p>
+              <dl class="simple">
+                <dt>keep_blank_values: flag indicating whether blank values in</dt>
+                <dd>
+                  <p>percent-encoded queries should be treated as blank strings.
+                    A true value indicates that blanks should be retained as
+                    blank strings. The default false value indicates that
+                    blank values are to be ignored and treated as if they were
+                    not included.</p>
+                </dd>
+                <dt>strict_parsing: flag indicating what to do with parsing errors.</dt>
+                <dd>
+                  <p>If false (the default), errors are silently ignored.
+                    If true, errors raise a ValueError exception.</p>
+                </dd>
+                <dt>encoding and errors: specify how to decode percent-encoded sequences</dt>
+                <dd>
+                  <p>into Unicode characters, as accepted by the bytes.decode() method.</p>
+                </dd>
+                <dt>max_num_fields: int. If set, then throws a ValueError if there</dt>
+                <dd>
+                  <p>are more than n fields read by parse_qsl().</p>
+                </dd>
+                <dt>separator: str. The symbol to use for separating the query arguments.</dt>
+                <dd>
+                  <p>Defaults to &amp;.</p>
+                </dd>
+              </dl>
+              <p>Returns a dictionary.</p>
+            </dd>
+          </dl>
+
+          <dl class="py function">
+            <dt class="sig sig-object py" id="urllib.parse.parse_qsl">
+              <span class="sig-prename descclassname"><span class="pre">urllib.parse.</span></span><span class="sig-name descname"><span class="pre">parse_qsl</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">qs</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">keep_blank_values</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">False</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">strict_parsing</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">False</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">encoding</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">'utf-8'</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">errors</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">'replace'</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">max_num_fields</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">separator</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">'&amp;'</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/urllib/parse.html#parse_qsl"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#urllib.parse.parse_qsl" title="Link to this definition">¶</a>
+            </dt>
+            <dd>
+              <p>Parse a query given as a string argument.</p>
+              <p>Arguments:</p>
+              <p>qs: percent-encoded query string to be parsed</p>
+              <dl class="simple">
+                <dt>keep_blank_values: flag indicating whether blank values in</dt>
+                <dd>
+                  <p>percent-encoded queries should be treated as blank strings.
+                    A true value indicates that blanks should be retained as blank
+                    strings. The default false value indicates that blank values
+                    are to be ignored and treated as if they were not included.</p>
+                </dd>
+                <dt>strict_parsing: flag indicating what to do with parsing errors. If</dt>
+                <dd>
+                  <p>false (the default), errors are silently ignored. If true,
+                    errors raise a ValueError exception.</p>
+                </dd>
+                <dt>encoding and errors: specify how to decode percent-encoded sequences</dt>
+                <dd>
+                  <p>into Unicode characters, as accepted by the bytes.decode() method.</p>
+                </dd>
+                <dt>max_num_fields: int. If set, then throws a ValueError</dt>
+                <dd>
+                  <p>if there are more than n fields read by parse_qsl().</p>
+                </dd>
+                <dt>separator: str. The symbol to use for separating the query arguments.</dt>
+                <dd>
+                  <p>Defaults to &amp;.</p>
+                </dd>
+              </dl>
+              <p>Returns a list, as G-d intended.</p>
+            </dd>
+          </dl>
+
+          <dl class="py function">
+            <dt class="sig sig-object py" id="urllib.parse.quote">
+              <span class="sig-prename descclassname"><span class="pre">urllib.parse.</span></span><span class="sig-name descname"><span class="pre">quote</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">'abc</span> <span class="pre">def'</span></span></em><span class="sig-paren">)</span> <span class="sig-return"><span class="sig-return-icon">&#x2192;</span> <span class="sig-return-typehint"><span class="s"><span class="pre">'abc%20def'</span></span></span></span><a class="reference internal" href="../_modules/urllib/parse.html#quote"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#urllib.parse.quote" title="Link to this definition">¶</a>
+            </dt>
+            <dd>
+              <p>Each part of a URL, e.g. the path info, the query, etc., has a
+                different set of reserved characters that must be quoted. The
+                quote function offers a cautious (not minimal) way to quote a
+                string for most of these parts.</p>
+              <p>RFC 3986 Uniform Resource Identifier (URI): Generic Syntax lists
+                the following (un)reserved characters.</p>
+              <p>unreserved = ALPHA / DIGIT / “-” / “.” / “_” / “~”
+                reserved = gen-delims / sub-delims
+                gen-delims = “:” / “/” / “?” / “#” / “[” / “]” / “&#64;”
+                sub-delims = “!” / “$” / “&amp;” / “’” / “(” / “)”</p>
+              <blockquote>
+                <div>
+                  <p>/ “*” / “+” / “,” / “;” / “=”</p>
+                </div>
+              </blockquote>
+              <p>Each of the reserved characters is reserved in some component of a URL,
+                but not necessarily in all of them.</p>
+              <p>The quote function %-escapes all characters that are neither in the
+                unreserved chars (“always safe”) nor the additional chars set via the
+                safe arg.</p>
+              <p>The default for the safe arg is ‘/’. The character is reserved, but in
+                typical usage the quote function is being called on a path where the
+                existing slash characters are to be preserved.</p>
+              <p>Python 3.7 updates from using RFC 2396 to RFC 3986 to quote URL strings.
+                Now, “~” is included in the set of unreserved characters.</p>
+              <p>string and safe may be either str or bytes objects. encoding and errors
+                must not be specified if string is a bytes object.</p>
+              <p>The optional encoding and errors parameters specify how to deal with
+                non-ASCII characters, as accepted by the str.encode method.
+                By default, encoding=’utf-8’ (characters are encoded with UTF-8), and
+                errors=’strict’ (unsupported characters raise a UnicodeEncodeError).</p>
+            </dd>
+          </dl>
+
+          <dl class="py function">
+            <dt class="sig sig-object py" id="urllib.parse.quote_from_bytes">
+              <span class="sig-prename descclassname"><span class="pre">urllib.parse.</span></span><span class="sig-name descname"><span class="pre">quote_from_bytes</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">bs</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">safe</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">'/'</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/urllib/parse.html#quote_from_bytes"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#urllib.parse.quote_from_bytes" title="Link to this definition">¶</a>
+            </dt>
+            <dd>
+              <p>Like quote(), but accepts a bytes object rather than a str, and does
+                not perform string-to-bytes encoding. It always returns an ASCII string.
+                quote_from_bytes(b’abc def?’) -&gt; ‘abc%20def%3f’</p>
+            </dd>
+          </dl>
+
+          <dl class="py function">
+            <dt class="sig sig-object py" id="urllib.parse.quote_plus">
+              <span class="sig-prename descclassname"><span class="pre">urllib.parse.</span></span><span class="sig-name descname"><span class="pre">quote_plus</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">string</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">safe</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">''</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">encoding</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">errors</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/urllib/parse.html#quote_plus"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#urllib.parse.quote_plus" title="Link to this definition">¶</a>
+            </dt>
+            <dd>
+              <p>Like quote(), but also replace ‘ ‘ with ‘+’, as required for quoting
+                HTML form values. Plus signs in the original string are escaped unless
+                they are included in safe. It also does not have safe default to ‘/’.</p>
+            </dd>
+          </dl>
+
+          <dl class="py function">
+            <dt class="sig sig-object py" id="urllib.parse.unquote">
+              <span class="sig-prename descclassname"><span class="pre">urllib.parse.</span></span><span class="sig-name descname"><span class="pre">unquote</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">string</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">encoding</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">'utf-8'</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">errors</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">'replace'</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/urllib/parse.html#unquote"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#urllib.parse.unquote" title="Link to this definition">¶</a>
+            </dt>
+            <dd>
+              <p>Replace %xx escapes by their single-character equivalent. The optional
+                encoding and errors parameters specify how to decode percent-encoded
+                sequences into Unicode characters, as accepted by the bytes.decode()
+                method.
+                By default, percent-encoded sequences are decoded with UTF-8, and invalid
+                sequences are replaced by a placeholder character.</p>
+              <p>unquote(‘abc%20def’) -&gt; ‘abc def’.</p>
+            </dd>
+          </dl>
+
+          <dl class="py function">
+            <dt class="sig sig-object py" id="urllib.parse.unquote_plus">
+              <span class="sig-prename descclassname"><span class="pre">urllib.parse.</span></span><span class="sig-name descname"><span class="pre">unquote_plus</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">string</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">encoding</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">'utf-8'</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">errors</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">'replace'</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/urllib/parse.html#unquote_plus"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#urllib.parse.unquote_plus" title="Link to this definition">¶</a>
+            </dt>
+            <dd>
+              <p>Like unquote(), but also replace plus signs by spaces, as required for
+                unquoting HTML form values.</p>
+              <p>unquote_plus(‘%7e/abc+def’) -&gt; ‘~/abc def’</p>
+            </dd>
+          </dl>
+
+          <dl class="py function">
+            <dt class="sig sig-object py" id="urllib.parse.unquote_to_bytes">
+              <span class="sig-prename descclassname"><span class="pre">urllib.parse.</span></span><span class="sig-name descname"><span class="pre">unquote_to_bytes</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">'abc%20def'</span></span></em><span class="sig-paren">)</span> <span class="sig-return"><span class="sig-return-icon">&#x2192;</span> <span class="sig-return-typehint"><span class="pre">b'abc</span> <span class="pre">def'.</span></span></span><a class="reference internal" href="../_modules/urllib/parse.html#unquote_to_bytes"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#urllib.parse.unquote_to_bytes" title="Link to this definition">¶</a>
+            </dt>
+            <dd></dd>
+          </dl>
+
+          <dl class="py function">
+            <dt class="sig sig-object py" id="urllib.parse.urldefrag">
+              <span class="sig-prename descclassname"><span class="pre">urllib.parse.</span></span><span class="sig-name descname"><span class="pre">urldefrag</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">url</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/urllib/parse.html#urldefrag"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#urllib.parse.urldefrag" title="Link to this definition">¶</a>
+            </dt>
+            <dd>
+              <p>Removes any existing fragment from URL.</p>
+              <p>Returns a tuple of the defragmented URL and the fragment. If
+                the URL contained no fragments, the second element is the
+                empty string.</p>
+            </dd>
+          </dl>
+
+          <dl class="py function">
+            <dt class="sig sig-object py" id="urllib.parse.urlencode">
+              <span class="sig-prename descclassname"><span class="pre">urllib.parse.</span></span><span class="sig-name descname"><span class="pre">urlencode</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">query</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">doseq=False</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">safe=''</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">encoding=None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">errors=None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">quote_via=&lt;function</span> <span class="pre">quote_plus&gt;</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/urllib/parse.html#urlencode"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#urllib.parse.urlencode" title="Link to this definition">¶</a>
+            </dt>
+            <dd>
+              <p>Encode a dict or sequence of two-element tuples into a URL query string.</p>
+              <p>If any values in the query arg are sequences and doseq is true, each
+                sequence element is converted to a separate parameter.</p>
+              <p>If the query arg is a sequence of two-element tuples, the order of the
+                parameters in the output will match the order of parameters in the
+                input.</p>
+              <p>The components of a query arg may each be either a string or a bytes type.</p>
+              <p>The safe, encoding, and errors parameters are passed down to the function
+                specified by quote_via (encoding and errors only if a component is a str).</p>
+            </dd>
+          </dl>
+
+          <dl class="py function">
+            <dt class="sig sig-object py" id="urllib.parse.urljoin">
+              <span class="sig-prename descclassname"><span class="pre">urllib.parse.</span></span><span class="sig-name descname"><span class="pre">urljoin</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">base</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">url</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">allow_fragments</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">True</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/urllib/parse.html#urljoin"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#urllib.parse.urljoin" title="Link to this definition">¶</a>
+            </dt>
+            <dd>
+              <p>Join a base URL and a possibly relative URL to form an absolute
+                interpretation of the latter.</p>
+            </dd>
+          </dl>
+
+          <dl class="py function">
+            <dt class="sig sig-object py" id="urllib.parse.urlparse">
+              <span class="sig-prename descclassname"><span class="pre">urllib.parse.</span></span><span class="sig-name descname"><span class="pre">urlparse</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">url</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">scheme</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">''</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">allow_fragments</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">True</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/urllib/parse.html#urlparse"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#urllib.parse.urlparse" title="Link to this definition">¶</a>
+            </dt>
+            <dd>
+              <p>Parse a URL into 6 components:
+                &lt;scheme&gt;://&lt;netloc&gt;/&lt;path&gt;;&lt;params&gt;?&lt;query&gt;#&lt;fragment&gt;</p>
+              <p>The result is a named 6-tuple with fields corresponding to the
+                above. It is either a ParseResult or ParseResultBytes object,
+                depending on the type of the url parameter.</p>
+              <p>The username, password, hostname, and port sub-components of netloc
+                can also be accessed as attributes of the returned object.</p>
+              <p>The scheme argument provides the default value of the scheme
+                component when no scheme is found in url.</p>
+              <p>If allow_fragments is False, no attempt is made to separate the
+                fragment component from the previous component, which can be either
+                path or query.</p>
+              <p>Note that % escapes are not expanded.</p>
+            </dd>
+          </dl>
+
+          <dl class="py function">
+            <dt class="sig sig-object py" id="urllib.parse.urlsplit">
+              <span class="sig-prename descclassname"><span class="pre">urllib.parse.</span></span><span class="sig-name descname"><span class="pre">urlsplit</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">url</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">scheme</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">''</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">allow_fragments</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">True</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/urllib/parse.html#urlsplit"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#urllib.parse.urlsplit" title="Link to this definition">¶</a>
+            </dt>
+            <dd>
+              <p>Parse a URL into 5 components:
+                &lt;scheme&gt;://&lt;netloc&gt;/&lt;path&gt;?&lt;query&gt;#&lt;fragment&gt;</p>
+              <p>The result is a named 5-tuple with fields corresponding to the
+                above. It is either a SplitResult or SplitResultBytes object,
+                depending on the type of the url parameter.</p>
+              <p>The username, password, hostname, and port sub-components of netloc
+                can also be accessed as attributes of the returned object.</p>
+              <p>The scheme argument provides the default value of the scheme
+                component when no scheme is found in url.</p>
+              <p>If allow_fragments is False, no attempt is made to separate the
+                fragment component from the previous component, which can be either
+                path or query.</p>
+              <p>Note that % escapes are not expanded.</p>
+            </dd>
+          </dl>
+
+          <dl class="py function">
+            <dt class="sig sig-object py" id="urllib.parse.urlunparse">
+              <span class="sig-prename descclassname"><span class="pre">urllib.parse.</span></span><span class="sig-name descname"><span class="pre">urlunparse</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">components</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/urllib/parse.html#urlunparse"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#urllib.parse.urlunparse" title="Link to this definition">¶</a>
+            </dt>
+            <dd>
+              <p>Put a parsed URL back together again. This may result in a
+                slightly different, but equivalent URL, if the URL that was parsed
+                originally had redundant delimiters, e.g. a ? with an empty query
+                (the draft states that these are equivalent).</p>
+            </dd>
+          </dl>
+
+          <dl class="py function">
+            <dt class="sig sig-object py" id="urllib.parse.urlunsplit">
+              <span class="sig-prename descclassname"><span class="pre">urllib.parse.</span></span><span class="sig-name descname"><span class="pre">urlunsplit</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">components</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/urllib/parse.html#urlunsplit"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#urllib.parse.urlunsplit" title="Link to this definition">¶</a>
+            </dt>
+            <dd>
+              <p>Combine the elements of a tuple as returned by urlsplit() into a
+                complete URL as a string. The data argument can be any five-item iterable.
+                This may result in a slightly different, but equivalent URL, if the URL that
+                was parsed originally had unnecessary delimiters (for example, a ? with an
+                empty query; the RFC states that these are equivalent).</p>
+            </dd>
+          </dl>
+
+        </section>
+
+      </article>
+
+      <aside class="nftt-toc">
+        <div class="mt-3 mb-1 my-lg-0 ps-xl-3 text-muted">
+          <button class="btn btn-link link-dark p-lg-0 mb-2 mb-lg-0 text-decoration-none nftt-toc-toggle d-lg-none" type="button" data-bs-toggle="collapse" data-bs-target="#tocContents" aria-expanded="false" aria-controls="tocContents">On this page <i class="ms-2 bi bi-chevron-expand"></i></button>
+          <div class="title d-none d-lg-block">
+            <i class="bi bi-file-earmark-text"></i>&nbsp;&nbsp;<span class="small">On this page</span>
+          </div>
+          <div class="collapse nftt-toc-collapse" id="tocContents">
+            <nav id="TableOfContents">
+              <ul>
+                <li><a class="reference internal" href="#">API documentation</a>
+                  <ul>
+                    <li><a class="reference internal" href="#urllib.parse.DefragResult"><code class="docutils literal notranslate"><span class="pre">urllib.parse.DefragResult</span></code></a></li>
+                    <li><a class="reference internal" href="#urllib.parse.DefragResultBytes"><code class="docutils literal notranslate"><span class="pre">urllib.parse.DefragResultBytes</span></code></a></li>
+                    <li><a class="reference internal" href="#urllib.parse.ParseResult"><code class="docutils literal notranslate"><span class="pre">urllib.parse.ParseResult</span></code></a></li>
+                    <li><a class="reference internal" href="#urllib.parse.ParseResultBytes"><code class="docutils literal notranslate"><span class="pre">urllib.parse.ParseResultBytes</span></code></a></li>
+                    <li><a class="reference internal" href="#urllib.parse.SplitResult"><code class="docutils literal notranslate"><span class="pre">urllib.parse.SplitResult</span></code></a></li>
+                    <li><a class="reference internal" href="#urllib.parse.SplitResultBytes"><code class="docutils literal notranslate"><span class="pre">urllib.parse.SplitResultBytes</span></code></a></li>
+                    <li><a class="reference internal" href="#urllib.parse.parse_qs"><code class="docutils literal notranslate"><span class="pre">urllib.parse.parse_qs()</span></code></a></li>
+                    <li><a class="reference internal" href="#urllib.parse.parse_qsl"><code class="docutils literal notranslate"><span class="pre">urllib.parse.parse_qsl()</span></code></a></li>
+                    <li><a class="reference internal" href="#urllib.parse.quote"><code class="docutils literal notranslate"><span class="pre">urllib.parse.quote()</span></code></a></li>
+                    <li><a class="reference internal" href="#urllib.parse.quote_from_bytes"><code class="docutils literal notranslate"><span class="pre">urllib.parse.quote_from_bytes()</span></code></a></li>
+                    <li><a class="reference internal" href="#urllib.parse.quote_plus"><code class="docutils literal notranslate"><span class="pre">urllib.parse.quote_plus()</span></code></a></li>
+                    <li><a class="reference internal" href="#urllib.parse.unquote"><code class="docutils literal notranslate"><span class="pre">urllib.parse.unquote()</span></code></a></li>
+                    <li><a class="reference internal" href="#urllib.parse.unquote_plus"><code class="docutils literal notranslate"><span class="pre">urllib.parse.unquote_plus()</span></code></a></li>
+                    <li><a class="reference internal" href="#urllib.parse.unquote_to_bytes"><code class="docutils literal notranslate"><span class="pre">urllib.parse.unquote_to_bytes()</span></code></a></li>
+                    <li><a class="reference internal" href="#urllib.parse.urldefrag"><code class="docutils literal notranslate"><span class="pre">urllib.parse.urldefrag()</span></code></a></li>
+                    <li><a class="reference internal" href="#urllib.parse.urlencode"><code class="docutils literal notranslate"><span class="pre">urllib.parse.urlencode()</span></code></a></li>
+                    <li><a class="reference internal" href="#urllib.parse.urljoin"><code class="docutils literal notranslate"><span class="pre">urllib.parse.urljoin()</span></code></a></li>
+                    <li><a class="reference internal" href="#urllib.parse.urlparse"><code class="docutils literal notranslate"><span class="pre">urllib.parse.urlparse()</span></code></a></li>
+                    <li><a class="reference internal" href="#urllib.parse.urlsplit"><code class="docutils literal notranslate"><span class="pre">urllib.parse.urlsplit()</span></code></a></li>
+                    <li><a class="reference internal" href="#urllib.parse.urlunparse"><code class="docutils literal notranslate"><span class="pre">urllib.parse.urlunparse()</span></code></a></li>
+                    <li><a class="reference internal" href="#urllib.parse.urlunsplit"><code class="docutils literal notranslate"><span class="pre">urllib.parse.urlunsplit()</span></code></a></li>
+                  </ul>
+                </li>
+              </ul>
+
+            </nav>
+          </div>
+        </div>
+      </aside>
+    </div>
+  </div>
+
+  <footer class="nftt-footer">
+    <nav class="py-4" aria-label="Documentation navigation">
+      <div class="container">
+        <ul class="pagination justify-content-between mb-0">
+          <li class="page-item">
+            <a class="d-flex px-xl-5 align-items-end" rel="prev" aria-label="Previous: Tralari">
+              <span class="prev-page">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-arrow-left" viewBox="0 0 16 16">
+                  <title>arrow previous</title>
+                  <path fill-rule="evenodd" d="M15 8a.5.5 0 0 0-.5-.5H2.707l3.147-3.146a.5.5 0 1 0-.708-.708l-4 4a.5.5 0 0 0 0 .708l4 4a.5.5 0 0 0 .708-.708L2.707 8.5H14.5A.5.5 0 0 0 15 8z" />
+                </svg>
+              </span>
+              <div class="d-flex flex-column">
+                <span class="text-small text-start">Previous</span>
+                <span>Nefertiti Theme documentation</span>
+              </div>
+            </a>
+          </li>
+
+          <li class="page-item ms-auto">
+            <a href="#next" class="d-flex px-xl-5 align-items-end" rel="next" aria-label="Next: Tralara">
+              <div class="d-flex flex-column">
+                <span class="text-small text-end text-muted">Next</span>
+                <span class="underline">Installation</span>
+              </div>
+              <span class="next-page">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-arrow-right" viewBox="0 0 16 16">
+                  <title>arrow next</title>
+                  <path fill-rule="evenodd" d="M1 8a.5.5 0 0 1 .5-.5h11.793l-3.147-3.146a.5.5 0 0 1 .708-.708l4 4a.5.5 0 0 1 0 .708l-4 4a.5.5 0 0 1-.708-.708L13.293 8.5H1.5A.5.5 0 0 1 1 8z" />
+                </svg>
+              </span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </nav>
+    <div class="py-5 px-4 px-md-3">
+      <div class="container">
+        <div class="row">
+          <ul class="list-unstyled list-separator col-lg-12 pb-4 text-center">
+            <li class="d-inline">
+              <a href="https://pypi.com/sphinx-nefertiti" class="list-item">Documentation</a>
+            </li>
+            <li class="d-inline">
+              <a href="https://pypi.com/sphinx-nefertiti" class="list-item">Package</a>
+            </li>
+            <li class="d-inline">
+              <a href="https://github.com/danirus/sphinx-nefertiti" class="list-item">Repository</a>
+            </li>
+            <li class="d-inline">
+              <a href="https://github.com/danirus/sphinx-nefertiti/issues" class="list-item">Issues</a>
+            </li>
+          </ul>
+        </div>
+        <div class="row">
+          <div class="col-lg-12 text-center">
+            <a class="brand-text d-inline-flex align-items-center mb-2 text-decoration-none" href="/" aria-label="Nefertiti-for-Sphinx">
+              <span class="fs-6 fw-bold">Nefertiti for Sphinx</span>
+            </a>
+            <ul class="list-unstyled text-muted">
+              <li>Code licensed <a href="https://github.com/danirus/sphinx-nefertiti/blob/main/LICENSE" target="_blank" rel="license noopener">MIT</a>, docs <a href="https://creativecommons.org/licenses/by/3.0/" target="_blank" rel="license noopener">CC BY 3.0</a>.</li>
+            </ul>
+            <div class="built-with pt-2">
+              Built with <a href="http://sphinx-doc.org">Sphinx 6.1.3</a> and <a href="https://github.com/danirus/sphinx-nefertiti">Nefertiti 0.1.0</a>.
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </footer>
+  <script src="/js/bootstrap.bundle.js"></script>
+  <script src="/js/sphinx-nefertiti.js"></script>
+  <!-- <script src="/js/colorsets.js" type="module"></script> -->
+</body>
+
+</html>

--- a/site/index_wo_toc.html
+++ b/site/index_wo_toc.html
@@ -301,7 +301,7 @@
   </header>
 
   <div class="container-fluid">
-    <div class="nftt-gutter nftt-page">
+    <div class="nftt-gutter nftt-page-wo-toc">
       <aside class="nftt-sidebar">
         <div class="nftt-sidebar-content">
           <div class="title d-none d-xl-block">
@@ -549,34 +549,6 @@ $ python -m http.server -d build/html</pre></div>
     </section>
       </article>
       <aside class="nftt-toc">
-        <div class="mt-3 mb-1 my-lg-0 ps-xl-3 text-muted">
-          <button class="btn btn-link link-dark p-lg-0 mb-2 mb-lg-0 text-decoration-none nftt-toc-toggle d-lg-none" type="button" data-bs-toggle="collapse" data-bs-target="#tocContents" aria-expanded="false" aria-controls="tocContents">
-            On this page
-            <i class="ms-2 bi bi-chevron-expand"></i>
-          </button>
-          <div class="title d-none d-lg-block">
-            <i class="bi bi-file-earmark-text"></i>&nbsp;&nbsp;<span class="small">On this page</span>
-          </div>
-          <div class="collapse nftt-toc-collapse" id="tocContents">
-            <nav id="TableOfContents">
-              <ul>
-                <li class=""><a class="reference internal" href="#quick-start">Quick start</a><ul>
-                <li class=""><a class="reference internal" href="#in-a-blink-of-an-eye">In a blink of an eye</a></li>
-                <li class=""><a class="reference internal" href="#customize-the-theme">Customize the theme</a><ul>
-                <li class=""><a class="reference internal" href="#fonts">1. Fonts</a></li>
-                <li class=""><a class="reference internal" href="#color-sets">2. Color sets</a></li>
-                <li class=""><a class="reference internal" href="#pygments-styles">3. Pygments styles</a></li>
-                <li class=""><a class="reference internal" href="#repository-data">4. Repository data</a></li>
-                <li class="active"><a class="reference internal" href="#version-dropdown">5. Version dropdown</a></li>
-                <li class=""><a class="reference internal" href="#footer-links">6. Footer links</a></li>
-                </ul>
-                </li>
-                </ul>
-                </li>
-                </ul>
-            </nav>
-          </div>
-        </div>
       </aside>
     </div>
   </div>

--- a/sphinx_nefertiti/__init__.py
+++ b/sphinx_nefertiti/__init__.py
@@ -1,10 +1,11 @@
 """sphinx-nefertiti theme"""
 
+import json
 from pathlib import Path
 import pkg_resources
 import sys
 
-from sphinx_nefertiti import colorsets, fonts, pygments
+from sphinx_nefertiti import colorsets, fonts, pygments, versions
 
 
 __version__ = pkg_resources.require("sphinx_nefertiti")[0].version
@@ -29,6 +30,9 @@ def initialize_theme(app):
         pygments_provider = pygments.PygmentsProvider(app)
         app.pygments_assets = [asset for asset in pygments_provider]
 
+        version_provider = versions.VersionProvider(app)
+        app.all_versions = [version for version in version_provider]
+
     except (fonts.FontNotSupportedException, Exception) as exc:
         print(exc)
         sys.exit(1)
@@ -47,6 +51,10 @@ def copy_nefertiti_files(app, exc):
 
     for asset in app.pygments_assets:
         asset.create_pygments_style_file(app.builder.outdir)
+
+    versions_json = Path(app.builder.outdir) / "_static" / "doc_versions.js"
+    with versions_json.open("w") as f:
+        f.write("const doc_versions = " + json.dumps(app.all_versions))
 
 
 def update_context(app, pagename, templatename, context, doctree):

--- a/sphinx_nefertiti/layout.html
+++ b/sphinx_nefertiti/layout.html
@@ -96,7 +96,7 @@
   </head>
   <body>
     <header class="navbar navbar-expand-xl navbar-dark nftt-navbar flex-column fixed-top">
-      <div class="skip-links container-xxl visually-hidden-focusable overflow-hidden justify-content-start">
+      <div class="skip-links container-fluid visually-hidden-focusable overflow-hidden justify-content-start">
         <div class="border-bottom mb-2 pb-2 w-100">
           <a class="d-none d-md-inline-flex p-2 m-1" href="#sidebar-filter">{{ _('Skip to docs navigation') }}</a>
           <a class="d-inline-flex p-2 m-1" href="#content">{{ _('Skip to main content') }}</a>
@@ -189,42 +189,42 @@
       </nav>
     </header>
 
-    <div class="container-fluid nftt-gutter nftt-layout">
-      <aside class="nftt-sidebar">
-        <div class="nftt-sidebar-content">
-          <div class="title d-none d-xl-block">
-            <i class="bi bi-book"></i>&nbsp;&nbsp;<span>{{ _('Index') }}</span>
+    <div class="container-fluid">
+      <div class="nftt-gutter {% if hidetoc %}nftt-page-wo-toc{% else %}nftt-page{% endif %}">
+        <aside class="nftt-sidebar">
+          <div class="nftt-sidebar-content">
+            <div class="title d-none d-xl-block">
+              <i class="bi bi-book"></i>&nbsp;&nbsp;<span>{{ _('Index') }}</span>
+            </div>
+            <div id="sidebar" tabindex="-1" class="offcanvas-xl offcanvas-start" aria-labelledby="nfttSidebarOffcanvasLabel">
+              {%- for sidebartemplate in sidebars %}
+                <!-- danirus sidebartemplate: "{{ sidebartemplate }}" -->
+                {%- include sidebartemplate %}
+              {%- endfor %}
+            </div>
           </div>
-          <div id="sidebar" tabindex="-1" class="offcanvas-xl offcanvas-start" aria-labelledby="nfttSidebarOffcanvasLabel">
-            {%- for sidebartemplate in sidebars %}
-              <!-- danirus sidebartemplate: "{{ sidebartemplate }}" -->
-              {%- include sidebartemplate %}
-            {%- endfor %}
-          </div>
-        </div>
-      </aside>
-      <main class="{% if hidetoc %}nftt-main-wo-toc{% else %}nftt-main{% endif %}">
+        </aside>
         <article id="content" class="nftt-content" role="main">
           {%- block body %}
           {% endblock -%}
         </article>
-        {% if display_toc and not hidetoc %}
-          <aside class="nftt-toc">
-            <div class="mt-3 mb-1 my-lg-0 ps-xl-3 text-muted">
-              <button class="btn btn-link link-dark p-lg-0 mb-2 mb-lg-0 text-decoration-none nftt-toc-toggle d-lg-none" type="button" data-bs-toggle="collapse" data-bs-target="#tocContents" aria-expanded="false" aria-controls="tocContents"
-              >On this page <i class="ms-2 bi bi-chevron-expand"></i></button>
-              <div class="title d-none d-lg-block">
-                <i class="bi bi-file-earmark-text"></i>&nbsp;&nbsp;<span class="small">On this page</span>
-              </div>
-              <div class="collapse nftt-toc-collapse" id="tocContents">
-                <nav id="TableOfContents">
-                  {{ toc }}
-                </nav>
-              </div>
+        <aside class="nftt-toc">
+          {% if display_toc and not hidetoc %}
+          <div class="mt-3 mb-1 my-lg-0 ps-xl-3 text-muted">
+            <button class="btn btn-link link-dark p-lg-0 mb-2 mb-lg-0 text-decoration-none nftt-toc-toggle d-lg-none" type="button" data-bs-toggle="collapse" data-bs-target="#tocContents" aria-expanded="false" aria-controls="tocContents"
+            >On this page <i class="ms-2 bi bi-chevron-expand"></i></button>
+            <div class="title d-none d-lg-block">
+              <i class="bi bi-file-earmark-text"></i>&nbsp;&nbsp;<span class="small">On this page</span>
             </div>
-          </aside>
-        {% endif %}
-      </main>
+            <div class="collapse nftt-toc-collapse" id="tocContents">
+              <nav id="TableOfContents">
+                {{ toc }}
+              </nav>
+            </div>
+          </div>
+          {% endif %}
+        </aside>
+      </div>
     </div>
 
     <footer class="nftt-footer">
@@ -241,5 +241,6 @@
     <script type="text/javascript" src="{{ pathto('_static/bootstrap.bundle.min.js', 1) }}"></script>
     <script type="text/javascript" src="{{ pathto('_static/sphinx-nefertiti.min.js', 1) }}"></script>
     {% if show_colorset_choices %}<script type="module" src="{{ pathto('_static/colorsets.js', 1) }}"></script>{% endif %}
+    <script type="text/javascript" src="{{ pathto('_static/doc_versions.js', 1) }}"></script>
   </body>
 </html>

--- a/sphinx_nefertiti/version-dropdown.html
+++ b/sphinx_nefertiti/version-dropdown.html
@@ -36,18 +36,10 @@
         <span id="snftt-version-text" class="d-xl-none small">{{ project|striptags|e }}</span>
         <span class="small ms-2" data-snftt-version-active="{{ theme_current_version }}">{{ theme_current_version }}</span>
       </a>
-      <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="snftt-version-text">
+      <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="snftt-version-text" id="versions-dropdown-menu">
         <li>
           <h6 class="dropdown-header">{{ _('Versions') }}</h6>
         </li>
-        {% for version, version_url in theme_versions %}
-          <li>
-            <a class="dropdown-item d-flex align-items-center justify-content-between" aria-pressed="false" href="{{ version_url }}" data-snftt-version-url="{{ version_url }}" data-snftt-version="{{ version }}">
-              <span class="small ms-2">{{ version }}</span>
-              <i class="bi bi-check ms-auto"></i>
-            </a>
-          </li>
-        {% endfor %}
       </ul>
     </li>
   {% endif %}

--- a/sphinx_nefertiti/versions.py
+++ b/sphinx_nefertiti/versions.py
@@ -9,7 +9,7 @@ class VersionProvider:
             return
 
         for name, url in theme_user_prefs["versions"]:
-            self._assets.append({ 'name': name, 'url': url })
+            self._assets.append({"name": name, "url": url})
 
     def __iter__(self):
         return self

--- a/sphinx_nefertiti/versions.py
+++ b/sphinx_nefertiti/versions.py
@@ -1,0 +1,21 @@
+class VersionProvider:
+    def __init__(self, app):
+        theme_user_prefs = app.config.html_theme_options
+
+        self._index = -1
+        self._assets = []
+
+        if not "versions" in theme_user_prefs:
+            return
+
+        for name, url in theme_user_prefs["versions"]:
+            self._assets.append({ 'name': name, 'url': url })
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        self._index += 1
+        if self._index >= len(self._assets):
+            raise StopIteration
+        return self._assets[self._index]


### PR DESCRIPTION
In this PR I provide a better way to handle the page layout. I removed the `nftt-layout` selector and created a new one `nftt-page` that contains 3 areas. The previous contained only two, and one of them was split into another two, that made impossible to center the layout while distributing the content at page's full width (`container-fluid`).

It also implements a different way to produce the list of versions, should the user decide to produce a dropdown with multiple versions. The new way consist of putting the list of versions in a js file called `doc_versions.js`. That file can be copied to other html static sites. I will document this in another PR.