### PR TITLE
Better support for versionchange directives

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,8 @@
 include README.md
 include requirements.txt
 
-recursive-include sphinx_nefertiti *.*
+recursive-include sphinx_nefertiti/colorsets *.*
+recursive-include sphinx_nefertiti/fonts **/*.*
+recursive-include sphinx_nefertiti/static/ *.*
 
 recursive-exclude sphinx_nefertiti *.pyc

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,6 @@ release_pattern_url = "https://sphinx-nefertiti.readthedocs.io/en/{release}/"
 
 releases = [
     release,
-    "0.0.3",
 ]
 
 # -- General configuration ---------------------------------------------------
@@ -76,11 +75,11 @@ pygments_dark_style = "dracula"
 
 html_theme_options = {
     "documentation_font": "Open Sans",
-    "documentation_font_size": "1.1rem",
+    "documentation_font_size": "1.0rem",
     "monospace_font": "Ubuntu Mono",
-    "monospace_font_size": "1.2rem",
+    "monospace_font_size": "1.1rem",
 
-    "style": "default",
+    "style": "orange",
 
     "logo": "img/nefertiti.svg",
     "logo_alt": "Nefertiti-for-Sphinx",

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -188,7 +188,7 @@ As an example, the 4 links of the current Nefertiti for Sphinx documentation loo
         ])
     }
 
-In addition you can remove the **Built with Sphinx and Nefertiti** notice by setting the ``show_powered_by`` key to False. It is ``True`` by default:
+In addition you can remove the **Built with Sphinx and Nefertiti** notice by setting the ``show_powered_by`` key to ``False``. It is ``True`` by default:
 
 .. code-block:: python
 

--- a/docs/source/users-guide/components/admonitions.rst
+++ b/docs/source/users-guide/components/admonitions.rst
@@ -1,8 +1,8 @@
 .. _admonitions:
 
-===========
+###########
 Admonitions
-===========
+###########
 
 A Sphinx admonition consist of three elements:
 
@@ -34,7 +34,7 @@ In both cases replace the ``type`` with any of the possible type of admonitions:
 
 
 Type: admonition
-================
+****************
 
 A custom admonition displayed as a **note** and with a title:
 
@@ -68,7 +68,7 @@ A custom admonition displayed as a **note** and with a title:
 
 
 Type: attention
-===============
+***************
 
 A sample **attention** admonition:
 
@@ -100,7 +100,7 @@ A sample **attention** admonition:
     Please, restart your computer.
 
 Type: caution
-=============
+*************
 
 A sample **caution** admonition:
 
@@ -129,7 +129,7 @@ A sample **caution** admonition:
     I have not had my coffee yet.
 
 Type: danger
-============
+************
 
 A sample **danger** admonition:
 
@@ -161,7 +161,7 @@ A sample **danger** admonition:
     Be aware that there is no way to recover them.
 
 Type: error
-===========
+***********
 
 A sample **error** admonition:
 
@@ -194,7 +194,7 @@ A sample **error** admonition:
     Your computer has been running for 10h 37m 23s. Microsoft does not allow a windows system to run longer than that. Your computer will now crash.
 
 Type: important
-===============
+***************
 
 A sample **important** admonition:
 
@@ -224,7 +224,7 @@ A sample **important** admonition:
 
 
 Type: note
-==========
+**********
 
 A sample **note** admonition:
 
@@ -254,7 +254,7 @@ A sample **note** admonition:
     just 8.752.239.254 seconds.
 
 Type: tip
-=========
+*********
 
 A sample **tip** admonition:
 
@@ -285,7 +285,7 @@ A sample **tip** admonition:
     Windows 95 was unable to detect your keyboard. Press F1 to retry or F2 to abort.
 
 Type: warning
-=============
+*************
 
 A sample **warning** admonition:
 

--- a/docs/source/users-guide/components/index.rst
+++ b/docs/source/users-guide/components/index.rst
@@ -13,6 +13,7 @@ The following pages contain examples of visual elements that can be included in 
    :maxdepth: 1
 
    admonitions
+   version-changes
    code-blocks
    headings
    images

--- a/docs/source/users-guide/components/version-changes.rst
+++ b/docs/source/users-guide/components/version-changes.rst
@@ -1,0 +1,313 @@
+.. _version-changes:
+
+###############
+Version changes
+###############
+
+Sphinx has support for a group of special directives to help describe changes between versions:
+
+* ``versionadded``
+* ``versionchanged``
+* ``deprecated``
+* ``versionremoved``
+
+To read about them, follow `this link <https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#describing-changes-between-versions>`_ to the Sphinx documentation.
+
+Examples
+********
+
+Directive examples without text
+===============================
+
+Examples of ``versionadded``, ``versionchanged``, ``deprecated`` and ``versionremoved`` getting only the version parameter.
+
+.. tab-set::
+
+    .. tab-item:: Markdown
+        :sync: md
+
+        .. code-block:: markdown
+
+            :::{versionadded} 5.15
+            :::
+
+        .. versionadded:: 5.15
+
+        |br|
+
+    .. tab-item:: reStructuredText
+        :sync: rst
+
+        .. code-block:: reStructuredText
+
+            .. versionadded:: 5.15
+
+        .. versionadded:: 5.15
+
+        |br|
+
+.. tab-set::
+
+    .. tab-item:: Markdown
+        :sync: md
+
+        .. code-block:: markdown
+
+            :::{versionchanged} 5.15
+            :::
+
+        .. versionchanged:: 5.15
+
+        |br|
+
+    .. tab-item:: reStructuredText
+        :sync: rst
+
+        .. code-block:: reStructuredText
+
+            .. versionchanged:: 5.15
+
+        .. versionchanged:: 5.15
+
+        |br|
+
+.. tab-set::
+
+    .. tab-item:: Markdown
+        :sync: md
+
+        .. code-block:: markdown
+
+            :::{deprecated} 5.15
+            :::
+
+        .. deprecated:: 5.15
+
+        |br|
+
+    .. tab-item:: reStructuredText
+        :sync: rst
+
+        .. code-block:: reStructuredText
+
+            .. deprecated:: 5.15
+
+        .. deprecated:: 5.15
+
+        |br|
+
+.. tab-set::
+
+    .. tab-item:: Markdown
+        :sync: md
+
+        .. code-block:: markdown
+
+            :::{versionremoved} 5.15
+            :::
+
+        .. versionremoved:: 5.15
+
+        |br|
+
+    .. tab-item:: reStructuredText
+        :sync: rst
+
+        .. code-block:: reStructuredText
+
+            .. versionremoved:: 5.15
+
+        .. versionremoved:: 5.15
+
+        |br|
+
+
+Directive examples with text
+============================
+
+Examples of ``versionadded``, ``versionchanged``, ``deprecated`` and ``versionremoved`` getting the version parameter and an explanatory text.
+
+.. tab-set::
+
+    .. tab-item:: Markdown
+        :sync: md
+
+        .. code-block:: markdown
+
+            :::{versionadded} 7.0
+            The date/time types datetime and timespan have been superseded by
+            the SQL92-defined types timestamp and interval. Although there has
+            been some effort to ease the transition by allowing PostgreSQL to
+            recognize the deprecated type names and translate them to the new
+            type names, this mechanism cannot be completely transparent to your
+            existing application.
+            :::
+
+        .. versionadded:: 7.0
+            The date/time types datetime and timespan have been superseded by
+            the SQL92-defined types timestamp and interval. Although there has
+            been some effort to ease the transition by allowing PostgreSQL to
+            recognize the deprecated type names and translate them to the new
+            type names, this mechanism cannot be completely transparent to your
+            existing application.
+
+    .. tab-item:: reStructuredText
+        :sync: rst
+
+        .. code-block:: reStructuredText
+
+            .. versionadded:: 7.0
+                The date/time types datetime and timespan have been superseded
+                by the SQL92-defined types timestamp and interval. Although
+                there has been some effort to ease the transition by allowing
+                PostgreSQL to recognize the deprecated type names and translate
+                them to the new type names, this mechanism cannot be completely
+                transparent to your existing application.
+
+        .. versionadded:: 7.0
+            The date/time types datetime and timespan have been superseded
+            by the SQL92-defined types timestamp and interval. Although
+            there has been some effort to ease the transition by allowing
+            PostgreSQL to recognize the deprecated type names and translate
+            them to the new type names, this mechanism cannot be completely
+            transparent to your existing application.
+
+.. tab-set::
+
+    .. tab-item:: Markdown
+        :sync: md
+
+        .. code-block:: markdown
+
+            :::{versionchanged} 7.0
+            The date/time types datetime and timespan have been superseded by
+            the SQL92-defined types timestamp and interval. Although there has
+            been some effort to ease the transition by allowing PostgreSQL to
+            recognize the deprecated type names and translate them to the new
+            type names, this mechanism cannot be completely transparent to your
+            existing application.
+            :::
+
+        .. versionchanged:: 7.0
+            The date/time types datetime and timespan have been superseded by
+            the SQL92-defined types timestamp and interval. Although there has
+            been some effort to ease the transition by allowing PostgreSQL to
+            recognize the deprecated type names and translate them to the new
+            type names, this mechanism cannot be completely transparent to your
+            existing application.
+
+    .. tab-item:: reStructuredText
+        :sync: rst
+
+        .. code-block:: reStructuredText
+
+            .. versionchanged:: 7.0
+                The date/time types datetime and timespan have been superseded
+                by the SQL92-defined types timestamp and interval. Although
+                there has been some effort to ease the transition by allowing
+                PostgreSQL to recognize the deprecated type names and translate
+                them to the new type names, this mechanism cannot be completely
+                transparent to your existing application.
+
+        .. versionchanged:: 7.0
+            The date/time types datetime and timespan have been superseded
+            by the SQL92-defined types timestamp and interval. Although
+            there has been some effort to ease the transition by allowing
+            PostgreSQL to recognize the deprecated type names and translate
+            them to the new type names, this mechanism cannot be completely
+            transparent to your existing application.
+
+.. tab-set::
+
+    .. tab-item:: Markdown
+        :sync: md
+
+        .. code-block:: markdown
+
+            :::{deprecated} 7.0
+            The date/time types datetime and timespan have been superseded by
+            the SQL92-defined types timestamp and interval. Although there has
+            been some effort to ease the transition by allowing PostgreSQL to
+            recognize the deprecated type names and translate them to the new
+            type names, this mechanism cannot be completely transparent to your
+            existing application.
+            :::
+
+        .. deprecated:: 7.0
+            The date/time types datetime and timespan have been superseded by
+            the SQL92-defined types timestamp and interval. Although there has
+            been some effort to ease the transition by allowing PostgreSQL to
+            recognize the deprecated type names and translate them to the new
+            type names, this mechanism cannot be completely transparent to your
+            existing application.
+
+    .. tab-item:: reStructuredText
+        :sync: rst
+
+        .. code-block:: reStructuredText
+
+            .. deprecated:: 7.0
+                The date/time types datetime and timespan have been superseded
+                by the SQL92-defined types timestamp and interval. Although
+                there has been some effort to ease the transition by allowing
+                PostgreSQL to recognize the deprecated type names and translate
+                them to the new type names, this mechanism cannot be completely
+                transparent to your existing application.
+
+        .. deprecated:: 7.0
+            The date/time types datetime and timespan have been superseded
+            by the SQL92-defined types timestamp and interval. Although
+            there has been some effort to ease the transition by allowing
+            PostgreSQL to recognize the deprecated type names and translate
+            them to the new type names, this mechanism cannot be completely
+            transparent to your existing application.
+
+.. tab-set::
+
+    .. tab-item:: Markdown
+        :sync: md
+
+        .. code-block:: markdown
+
+            :::{versionremoved} 7.0
+            The date/time types datetime and timespan have been superseded by
+            the SQL92-defined types timestamp and interval. Although there has
+            been some effort to ease the transition by allowing PostgreSQL to
+            recognize the deprecated type names and translate them to the new
+            type names, this mechanism cannot be completely transparent to your
+            existing application.
+            :::
+
+        .. versionremoved:: 7.0
+            The date/time types datetime and timespan have been superseded by
+            the SQL92-defined types timestamp and interval. Although there has
+            been some effort to ease the transition by allowing PostgreSQL to
+            recognize the deprecated type names and translate them to the new
+            type names, this mechanism cannot be completely transparent to your
+            existing application.
+
+    .. tab-item:: reStructuredText
+        :sync: rst
+
+        .. code-block:: reStructuredText
+
+            .. versionremoved:: 7.0
+                The date/time types datetime and timespan have been superseded
+                by the SQL92-defined types timestamp and interval. Although
+                there has been some effort to ease the transition by allowing
+                PostgreSQL to recognize the deprecated type names and translate
+                them to the new type names, this mechanism cannot be completely
+                transparent to your existing application.
+
+        .. versionremoved:: 7.0
+            The date/time types datetime and timespan have been superseded
+            by the SQL92-defined types timestamp and interval. Although
+            there has been some effort to ease the transition by allowing
+            PostgreSQL to recognize the deprecated type names and translate
+            them to the new type names, this mechanism cannot be completely
+            transparent to your existing application.
+
+
+.. |br| raw:: html
+
+     <p/>

--- a/docs/source/users-guide/customization/fonts.rst
+++ b/docs/source/users-guide/customization/fonts.rst
@@ -3,7 +3,7 @@
 Fonts
 #####
 
-This document explains how you can customize your Sphinx project to use one of the fonts bundled with Nefertiti for Sphinx. It also explains how to add other fonts to your project.
+This document explains how you can customize your Sphinx project to use the fonts bundled with Nefertiti for Sphinx. It also explains how to add other fonts to your project.
 
 About EU's GDPR
 ***************
@@ -12,7 +12,7 @@ Nefertiti for Sphinx does not redirect HTTP font requests to 3rd party providers
 
 When serving EU based users, so long as you get the user's consent, you can still redirect font requests to a 3rd party font service provider. But Nefertiti for Sphinx does not provide the consent modal window, nor the logic in the case the user does not consent.
 
-Instead, add your preferred fonts and use them with your Sphinx project. The section :ref:`adding-fonts` below explains the details.
+You can instead, as explained below, use one of the fonts distributed with Nefertiti for Sphinx, or otherwise add your preferred fonts. The section :ref:`adding-fonts` below explains the details.
 
 Font settings
 *************

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -116,4 +116,38 @@ window.addEventListener('DOMContentLoaded', (_) => {
     table.before(wrapper);
     wrapper.append(table);
   }
+
+  // Fix admonitions-like blocks used in Sphinx to display version
+  // changes. Such directives are: versionadded, versionchanged,
+  // deprecated, and versionremoved.
+  const vchanges_selectors = [
+    ["div.versionadded", "versionadded", "versionadded-title-only"],
+    ["div.versionchanged", "versionchanged", "versionchanged-title-only"],
+    ["div.deprecated", "deprecated", "deprecated-title-only"],
+    ["div.versionremoved", "versionremoved", "versionremoved-title-only"],
+  ];
+  for (const lst of vchanges_selectors) {
+    const [ selector, src_class, tgt_class ] = lst;
+    const elems = document.querySelectorAll(selector);
+    if (elems.length > 0) {
+      console.log(`I found ${elems.length} elements of selector ${selector}`);
+    } else {
+      console.log(`I didn't find any ${selector} element.`)
+    }
+
+    for (const div of elems) {
+      // The 'p' contained in the div might contain just a <span>, or
+      // a <span> and a text node. The 2nd case is when the versionadded
+      // directive receives additional text, right below the directive.
+      // If the directive only gets the version number, without
+      // additional text below, then I the selector should
+      // change to .versionadded-title-only, so that it
+      // does not display an empty block below.
+
+      if (div.querySelector("p").childNodes.length == 1) {
+        console.log(`Replacing ${selector} selector...`);
+        div.classList.replace(src_class, tgt_class);
+      }
+    }
+  }
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sphinx-nefertiti",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "description": "Nefertiti is a theme for the Sphinx Documentation Generator.",
   "engines": {
@@ -77,6 +77,6 @@
   },
   "dependencies": {
     "@octokit/rest": "^19.0.5",
-    "bootstrap": "5.3.2"
+    "bootstrap": "5.3.3"
   }
 }

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,8 +1,6 @@
--rrequirements.txt
-
-myst-parser>=2.0.0,<2.1
-pygments>=2.15.1,<2.16
-sphinx-intl>=2.0,<2.2
-sphinx-design>=0.4,<0.5
-sphinx_copybutton>=0.5.0,<1.0.0
-sphinx-nefertiti>=0.3.3
+sphinx>=7.4.7,<8
+myst-parser>=3.0.1,<3.1
+sphinx-intl>=2.2.0,<2.3
+sphinx-design>=0.6.0,<0.7
+sphinx_copybutton>=0.5.2,<1.0.0
+sphinx-nefertiti>=0.3.5

--- a/scss/components/_admonitions.scss
+++ b/scss/components/_admonitions.scss
@@ -113,7 +113,7 @@ div.versionremoved {
   margin: 2.5rem 2rem;
   border: 2px solid transparent;
 
-  & > p {
+  > p {
     margin-bottom: 0;
   }
 
@@ -137,7 +137,7 @@ div.versionremoved {
   margin: 2.5rem 2rem;
   border: 2px solid transparent;
 
-  & > p {
+  > p {
     margin-bottom: 0;
   }
 
@@ -161,7 +161,7 @@ div.deprecated-title-only {
   margin: 2.5rem 2rem;
   border: 2px solid transparent;
 
-  & > p {
+  > p {
     margin-bottom: 0;
   }
 
@@ -185,7 +185,7 @@ div.deprecated-title-only {
   margin: 2.5rem 2rem;
   border: 2px solid transparent;
 
-  & > p {
+  > p {
     margin-bottom: 0;
   }
 

--- a/scss/components/_admonitions.scss
+++ b/scss/components/_admonitions.scss
@@ -1,4 +1,5 @@
 /* stylelint-disable selector-no-qualifying-type */
+
 .versionadded {
   padding: .7rem 1.2rem 1rem;
   margin: 2.5rem 2rem 2rem;
@@ -33,7 +34,7 @@
   border: 2px solid var(--#{$prefix}admon-caution-color-bg);
   border-radius: $border-radius;
 
-  .changeded,
+  .changed,
   .versionmodified {
     position: relative;
     top: -34px;
@@ -80,6 +81,128 @@ div.deprecated {
   }
 }
 
+div.versionremoved {
+  padding: .7rem 1.2rem 1rem;
+  margin: 2.5rem 2rem 2rem;
+  background-color: var(--#{$prefix}foot1-bg);
+  border: 2px solid var(--#{$prefix}admon-attention-color-bg);
+  border-radius: $border-radius;
+
+  span.removed,
+  span.versionmodified {
+    position: relative;
+    top: -34px;
+    left: 16px;
+    display: block;
+    min-width: 100px;
+    max-width: 318px;
+    padding: .3rem 1rem;
+    margin: -1rem;
+    font-weight: $font-weight-bold;
+    color: var(--#{$prefix}body-hc-color);
+    background-color: var(--#{$prefix}admon-attention-color-bg);
+  }
+
+  > p:first-child {
+    padding-top: 1.5rem;
+  }
+}
+
+.versionadded-title-only {
+  padding: 0 1.2rem;
+  margin: 2.5rem 2rem;
+  border: 2px solid transparent;
+
+  & > p {
+    margin-bottom: 0;
+  }
+
+  .added,
+  .versionmodified {
+    position: relative;
+    top: 0;
+    left: 16px;
+    display: block;
+    min-width: 100px;
+    max-width: 318px;
+    padding: .3rem 1rem;
+    margin: -1rem;
+    font-weight: $font-weight-bold;
+    background-color: var(--#{$prefix}admon-tip-color-bg);
+  }
+}
+
+.versionchanged-title-only {
+  padding: 0 1.2rem;
+  margin: 2.5rem 2rem;
+  border: 2px solid transparent;
+
+  & > p {
+    margin-bottom: 0;
+  }
+
+  .changed,
+  .versionmodified {
+    position: relative;
+    top: 0;
+    left: 16px;
+    display: block;
+    min-width: 100px;
+    max-width: 318px;
+    padding: .3rem 1rem;
+    margin: -1rem;
+    font-weight: $font-weight-bold;
+    background-color: var(--#{$prefix}admon-caution-color-bg);
+  }
+}
+
+div.deprecated-title-only {
+  padding: 0 1.2rem;
+  margin: 2.5rem 2rem;
+  border: 2px solid transparent;
+
+  & > p {
+    margin-bottom: 0;
+  }
+
+  .deprecated,
+  .versionmodified {
+    position: relative;
+    top: 0;
+    left: 16px;
+    display: block;
+    min-width: 100px;
+    max-width: 318px;
+    padding: .3rem 1rem;
+    margin: -1rem;
+    font-weight: $font-weight-bold;
+    background-color: var(--#{$prefix}admon-error-color-bg);
+  }
+}
+
+.versionremoved-title-only {
+  padding: 0 1.2rem;
+  margin: 2.5rem 2rem;
+  border: 2px solid transparent;
+
+  & > p {
+    margin-bottom: 0;
+  }
+
+  .removed,
+  .versionmodified {
+    position: relative;
+    top: 0;
+    left: 16px;
+    display: block;
+    min-width: 100px;
+    max-width: 318px;
+    padding: .3rem 1rem;
+    margin: -1rem;
+    font-weight: $font-weight-bold;
+    background-color: var(--#{$prefix}admon-attention-color-bg);
+  }
+}
 
 .admonition-title,
 aside.topic > .topic-title {

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(BASE_DIR / "requirements.txt", "r") as req_file:
 
 setup(
     name="sphinx-nefertiti",
-    version="0.3.4",
+    version="0.3.5",
     packages=find_packages(),
     include_package_data=True,
     license="MIT",
@@ -55,6 +55,5 @@ setup(
         "Topic :: Documentation",
         "Topic :: Software Development :: Documentation",
     ],
-    test_suite="dummy",
     zip_safe=True,
 )

--- a/sphinx_nefertiti/utils.py
+++ b/sphinx_nefertiti/utils.py
@@ -1,4 +1,4 @@
-_CURRENT_VERSION = (0, 3, 4, "f", 0)  # following PEP 440
+_CURRENT_VERSION = (0, 3, 5, "f", 0)  # following PEP 440
 
 
 def get_version():


### PR DESCRIPTION
This PR adds better support for version-change directives:
* `versionadded`
* `versionchanged`
* `deprecated`
* `versionremoved`

The difference with main is that when the directive does not contain the optional explanatory text it displayed an enclosing empty block. Now, when the explanatory text is not provided, the selector is changed to `${selector}-title-only`, via JavaScript. The new selector avoids rendering the enclosing empty block.
