### PR TITLE
Use pypa/gh-action-pypi-publish@release v1.12

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,7 +35,4 @@ jobs:
       - run: make build-ext
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.8
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1.12


### PR DESCRIPTION
It seems something is suddenly wrong in the publishing script.
I got it fixed in another repository using v1.12 of pypa/gh-action-pypi-publish.