### PR TITLE
Includes 'theme-color' meta tag

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,11 +1,15 @@
 # Change Log
 
-## [0.8.1] - 2025-01-03
+## [0.8.2] - 2025-06-07
+
+- Includes `theme-color` meta tag.
+
+## [0.8.1] - 2025-06-03
 
 - Use Ubuntu Sans Mono as default monospace font.
 - Fixes small issue in JavaScript plugin.
 
-## [0.8.0] - 2025-01-03
+## [0.8.0] - 2025-06-03
 
 - Add locale dropdown element. It shows up when declaring ``locales`` in the ``html_theme_options``.
 - Add documentation on localization (single language site, multilingual site).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sphinx-nefertiti",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "description": "Nefertiti is a theme for the Sphinx Documentation Generator.",
   "engines": {

--- a/sphinx_nefertiti/__init__.py
+++ b/sphinx_nefertiti/__init__.py
@@ -15,7 +15,7 @@ from sphinx_nefertiti import (
     pygments,
 )
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 
 pages_wo_index = ["genindex", "search"]
 
@@ -118,6 +118,7 @@ def update_context(app, pagename, templatename, context, doctree):
     context["theme_locales"] = getattr(app, "theme_locales", [])
     context["show_colorset_choices"] = app.show_colorset_choices
     context["all_colorsets"] = colorsets.all_colorsets
+    context["theme_colors"] = app.active_colorset.theme_colors
 
 
 def build_finished(app, exc):

--- a/sphinx_nefertiti/colorsets.py
+++ b/sphinx_nefertiti/colorsets.py
@@ -37,6 +37,61 @@ color_names = [
     _("cyan"),
 ]
 
+# Values to share in layout.html <meta name="theme-color" content="">.
+# Values for primary, light-neutral, dark-neutral, for every color theme.
+theme_colors = {
+    "blue": {
+        "primary": "#0D6EFD",
+        "light-neutral": "#CFE2FF",
+        "dark-neutral": "#031633",
+    },
+    "indigo": {
+        "primary": "#6610f2",
+        "light-neutral": "#E0CFFC",
+        "dark-neutral": "#140330",
+    },
+    "purple": {
+        "primary": "#6F42C1",
+        "light-neutral": "#E2D9F3",
+        "dark-neutral": "#160D27",
+    },
+    "pink": {
+        "primary": "#D63384",
+        "light-neutral": "#F7D6E6",
+        "dark-neutral": "#2B0A1A",
+    },
+    "red": {
+        "primary": "#DC3545",
+        "light-neutral": "#F8D7DA",
+        "dark-neutral": "#2C0B0E",
+    },
+    "orange": {
+        "primary": "#FD7E14",
+        "light-neutral": "#FFE5D0",
+        "dark-neutral": "#330F04",
+    },
+    "yellow": {
+        "primary": "#FFC107",
+        "light-neutral": "#FFF3CD",
+        "dark-neutral": "#332701",
+    },
+    "green": {
+        "primary": "#078349",
+        "light-neutral": "#CDE6DB",
+        "dark-neutral": "#011A0F",
+    },
+    "teal": {
+        "primary": "#20C997",
+        "light-neutral": "#D2F4EA",
+        "dark-neutral": "#06281E",
+    },
+    "default": {
+        "primary": "#0DCAF0",
+        "light-neutral": "#CFF4FC",
+        "dark-neutral": "#032830",
+    },
+}
+
 
 class ColorSet:
     def __init__(self, name, app):
@@ -47,6 +102,7 @@ class ColorSet:
                 f"Style 'hl({name})' is not known as a color set."
             )
         self._name = _name
+        self.theme_colors = theme_colors[self._name]
 
     @property
     def link_stylesheet(self):

--- a/sphinx_nefertiti/layout.html
+++ b/sphinx_nefertiti/layout.html
@@ -37,6 +37,12 @@
     <meta name="docsearch:package_type" content="{{ package_type|striptags|e }}" />
     <meta name="docsearch:release" content="{{ release|striptags|e }}" />
     <meta name="docsearch:version" content="{{ version|striptags|e }}" />
+    {% if theme_style_header_neutral is true %}
+      <meta name="theme-color" content="{{ theme_colors['light-neutral'] }}" media="(prefers-color-scheme: light)" />
+      <meta name="theme-color" content="{{ theme_colors['dark-neutral'] }}" media="(prefers-color-scheme: dark)" />
+    {% else %}
+      <meta name="theme-color" content="{{ theme_colors['primary'] }}" />
+    {% endif %}
     {% block htmltitle %}
       <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
     {% endblock %}


### PR DESCRIPTION
Includes `theme-color` meta tag in the `head` of `sphinx_nefertiti/layout.html`.