### PR TITLE
Fixes non-functional search result URLs ("undefined")

### DIFF
--- a/sphinx_nefertiti/layout.html
+++ b/sphinx_nefertiti/layout.html
@@ -24,7 +24,7 @@
     {%- endfor %}
 {%- endmacro %}
 <!DOCTYPE html>
-<html class="no-js" {% if language is not none %}lang="{{ language }}"{% endif %}>
+<html class="no-js" {% if language is not none %}lang="{{ language }}"{% endif %} data-content_root="{{ content_root }}">
   <head>
     <meta charset="utf-8" />
     {%- if metatags %}


### PR DESCRIPTION
Fixes non-functional search result URLs ("undefined") per <https://github.com/sphinx-doc/sphinx/commit/8e730ae303ae686705ea12f44ef11da926a87cf5>

This took me a while to figure out, but my Sphinx/nftt instance was not building search results properly; "`role=main`" console errors galore in the search results page, as well as "undefined" embedded in the search results URLs.

Stumbled upon the above upstream commit and this article... <https://documatt.com/blog/25/sphinx-builtin-search-theme/> which led me the right direction; `data-content_root` was not present in the `<html>` tag.

This tiny PR fixes the issue and search results work as intended. :-)