### PR TITLE
Fixed extention name (hyphens) and included extension URL

### DIFF
--- a/docs/source/users-guide/customization/last-updated.rst
+++ b/docs/source/users-guide/customization/last-updated.rst
@@ -3,9 +3,9 @@
 Last Updated Timestamp
 ######################
 
-If your Sphinx content is managed in ``git`` The Nefertiti theme can automatically insert a *"Last updated on <timestamp>"* in the footer for you.
+If your Sphinx content is managed in ``git``, the Nefertiti theme can automatically insert a *"Last updated on <timestamp>"* in the footer for you.
 
-To enable this feature, one must install the Sphinx extension, ``sphinx_last_updated_by_git``, and declare it in the ``conf.py``...
+To enable this feature, one must install the Sphinx extension, `sphinx-last-updated-by-git <https://pypi.org/project/sphinx-last-updated-by-git/>`_, and declare it in ``conf.py``...
 
 .. code-block:: python
 


### PR DESCRIPTION
Fixed a typo in the extension name (hyphens rather than underscores), and linked to the extension required for this feature. 