### PR TITLE
finish/fix tox config and test workflow.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,8 +7,9 @@ on:
 
 env:
   FORCE_COLOR: true
-  NODE: 20
-  PYTHON: 3.13
+  NODE: 24
+  # For non-matrix jobs/lint
+  PYTHON: 3.14
 
 permissions:
   contents: read
@@ -37,7 +38,43 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sphinx: ["7.3", "7.4", "8.0", "8.1"]
+        include:
+          - python: "3.13"
+            sphinx: "7.3"
+            tox-env: py3.13-sphinx7.3
+          - python: "3.13"
+            sphinx: "7.3"
+            tox-env: py3.13-sphinx7.3-test
+          - python: "3.13"
+            sphinx: "7.4"
+            tox-env: py3.13-sphinx7.4
+          - python: "3.13"
+            sphinx: "7.4"
+            tox-env: py3.13-sphinx7.4-test
+          - python: "3.13"
+            sphinx: "8.0"
+            tox-env: py3.13-sphinx8.0
+          - python: "3.13"
+            sphinx: "8.0"
+            tox-env: py3.13-sphinx8.0-test
+          - python: "3.13"
+            sphinx: "8.1"
+            tox-env: py3.13-sphinx8.1
+          - python: "3.13"
+            sphinx: "8.1"
+            tox-env: py3.13-sphinx8.1-test
+          - python: "3.14"
+            sphinx: "9.0"
+            tox-env: py3.14-sphinx9.0
+          - python: "3.14"
+            sphinx: "9.0"
+            tox-env: py3.14-sphinx9.0-test
+          - python: "3.14"
+            sphinx: "9.1"
+            tox-env: py3.14-sphinx9.1
+          - python: "3.14"
+            sphinx: "9.1"
+            tox-env: py3.14-sphinx9.1-test
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -48,14 +85,14 @@ jobs:
         run: npm ci
       - uses: actions/setup-python@v5
         with:
-          python-version: "${{ env.PYTHON }}"
+          python-version: "${{ matrix.python }}"
           cache: pip
       - name: Install deps
         run: pip install tox build
       - name: Create CSS bundles
         run: make build-ext
       - name: Run unit tests
-        run: tox -e py3.13-sphinx${{ matrix.sphinx }}
+        run: tox -e ${{ matrix.tox-env }}
 
   javascript-tests:
     runs-on: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -3,27 +3,32 @@ python_files = test_*.py
 
 [tox]
 skipsdist = True
-envlist = py3.14-sphinx{7.3,7.4,8.0,8.1,9.0,9.1}
+envlist =
+    py3.13-sphinx{7.3,7.4,8.0,8.1}
+    py3.13-sphinx{7.3,7.4,8.0,8.1}-test
+    py3.14-sphinx{9.0,9.1}
+    py3.14-sphinx{9.0,9.1}-test
 
 [testenv]
 changedir = {toxinidir}
 commands =
-    coverage erase
-    coverage run --source=sphinx_nefertiti -m pytest -sra
-    coverage report -m
+    !test: python -m sphinx -W -b html tests/sample_prj_1 {envtmpdir}/sample_prj_1_html
+    test: coverage erase
+    test: coverage run --source=sphinx_nefertiti -m pytest -sra
+    test: coverage report -m
 deps =
     .[dev]
     py3.13-sphinx7.3: sphinx>=7.3,<7.4
-    py3.13-sphinx7.3: sphinx[test]>=7.3,<7.4
+    py3.13-sphinx7.3-test: sphinx[test]>=7.3,<7.4
     py3.13-sphinx7.4: sphinx>=7.4,<7.5
-    py3.13-sphinx7.4: sphinx[test]>=7.4,<7.5
+    py3.13-sphinx7.4-test: sphinx[test]>=7.4,<7.5
     py3.13-sphinx8.0: sphinx>=8.0,<8.1
-    py3.13-sphinx8.0: sphinx[test]>=8.0,<8.1
+    py3.13-sphinx8.0-test: sphinx[test]>=8.0,<8.1
     py3.13-sphinx8.1: sphinx>=8.1,<8.2
-    py3.13-sphinx8.1: sphinx[test]>=8.1,<8.2
-    py3.13-sphinx9.0: sphinx>=9.0,<9.1
-    py3.13-sphinx9.0: sphinx[test]>=9.0,<9.1
-    py3.13-sphinx9.1: sphinx>=9.1,<9.2
-    py3.13-sphinx9.1: sphinx[test]>=9.1,<9.2
+    py3.13-sphinx8.1-test: sphinx[test]>=8.1,<8.2
+    py3.14-sphinx9.0: sphinx>=9.0,<9.1
+    py3.14-sphinx9.0-test: sphinx[test]>=9.0,<9.1
+    py3.14-sphinx9.1: sphinx>=9.1,<9.2
+    py3.14-sphinx9.1-test: sphinx[test]>=9.1,<9.2
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}


### PR DESCRIPTION
I'm not completely thrilled with the verbosity of this config, however, not convinced that GitHub Actions will expand arrays inside an `include` and I still want to be able simply run tox targets like `tox -e py3.13-sphinx7.3-test`.

Open to alternatives.